### PR TITLE
Add 'go vet' linter to CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,14 @@ jobs:
         - darwin/anticycle_amd64
         - windows/anticycle_amd64.exe
 
+  lint:
+    <<: *defaults
+    steps:
+    - checkout
+    - run:
+        name: Run linters
+        command: make lint
+
   unit-tests:
     <<: *defaults
     steps:
@@ -60,6 +68,9 @@ workflows:
         requires:
         - build
     - sanity-tests:
+        requires:
+        - build
+    - lint:
         requires:
         - build
 # TODO (pawelzny): Add job: acceptance-tests with full coverage for CLI

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ benchmark-save: ## save new benchmark as old
 
 format: ## reformat sourcecode
 	go fmt ./...
+
+lint: ## static checks
+	./tools/linter.sh

--- a/tools/linter.sh
+++ b/tools/linter.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o xtrace
+set -o history
+set -o histexpand
+
+# Exit on any errors so that errors don't compound
+trap err_trap ERR
+function err_trap {
+    local r=$?
+    set +o xtrace
+    echo "command: '$BASH_COMMAND' failed with status code $r"
+    exit ${r}
+}
+
+# Vet examines Go source code and reports suspicious constructs.
+# https://golang.org/cmd/vet/
+function check_vet() {
+    for dir in "${@:2}"
+    do
+        go vet -source "$1$dir/..."
+    done
+}
+
+# Prepare directories to check
+current_dir=$(dirname "$0")
+if [[ ${current_dir} == "." ]]; then
+    root_dir="../"
+else
+    root_dir="$current_dir/../"
+fi
+
+source_dirs=(
+    cmd
+    pkg
+    internal
+    test
+)
+
+# Run linters
+check_vet ${root_dir} ${source_dirs[@]}


### PR DESCRIPTION
First linter is a `go vet` command.
Closes: #17