### PR TITLE
Relative paths comparison error

### DIFF
--- a/internal/pkg/scan/scan.go
+++ b/internal/pkg/scan/scan.go
@@ -68,7 +68,7 @@ func FindCycles(packages []*model.Pkg) ([]*model.Pkg, error) {
 					// check which file is affected
 					for _, file := range packages[i].Files {
 						for _, imp := range file.Imports {
-							if imp.Name == packages[j].Path {
+							if strings.HasSuffix(imp.Name, packages[j].Path) {
 								cycle := &model.Cycle{
 									AffectedFile:   file.Path,
 									AffectedImport: imp,

--- a/pkg/anticycle/anticycle.go
+++ b/pkg/anticycle/anticycle.go
@@ -59,7 +59,6 @@ func onlyAffected(packages []*model.Pkg) []*model.Pkg {
 	var result []*model.Pkg
 	for _, pkg := range packages {
 		if pkg.HaveCycle {
-
 			imports := make(map[string]*model.ImportInfo, len(pkg.Cycles))
 			for _, cycle := range pkg.Cycles {
 				if imp, ok := pkg.Imports[cycle.AffectedImport.Name]; ok {
@@ -79,8 +78,10 @@ func onlyAffected(packages []*model.Pkg) []*model.Pkg {
 								fileImports = append(fileImports, imp)
 							}
 						}
-						file.Imports = fileImports
-						files = append(files, file)
+						if len(fileImports) > 0 {
+							file.Imports = fileImports
+							files = append(files, file)
+						}
 						break
 					}
 				}


### PR DESCRIPTION
`strings.Contains()` or strict comparison is not a good choice to compare relative path name with fully qualified import name. Strict compare changed to `strings.HasSuffix()`.
One more check for filter `onlyAffected` must be applied, because it may happen that cycle without affected import is produced. I have no idea why. Need investigation. 
Closes: #55